### PR TITLE
Dev

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,8 @@
                 "fredericbonnet.cmake-test-adapter",
                 "ms-vscode.cmake-tools",
                 "AndreasNonslidHvardsen.clang-tidy-on-active-file",
-                "ryanluker.vscode-coverage-gutters"
+                "ryanluker.vscode-coverage-gutters",
+                "streetsidesoftware.code-spell-checker"
             ]
         }
     },

--- a/README.md
+++ b/README.md
@@ -103,8 +103,7 @@ But it does not work with the mentioned containers.
 * Write benchmarks
 * Ignore google headers from clang-tidy
 * Consider checked access that returns an optional reference
-* Do not allow to mix begin/end with cbegin/cend
-* Run clang-tidy, clang-format in CI/file save
+* Run clang-tidy on file save
 * Cancel running jobs on new commit
 * Test
     * Analyze if LCOV_EXCL_LINE is needed

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ But it does not work with the mentioned containers.
 * Consider checked access that returns an optional reference
 * Do not allow to mix begin/end with cbegin/cend
 * Run clang-tidy, clang-format in CI/file save
+* Cancel running jobs on new commit
 * Test
     * Analyze if LCOV_EXCL_LINE is needed
     * Finish tests

--- a/README.md
+++ b/README.md
@@ -49,6 +49,39 @@ int main() {
 
 See [tests](tests/).
 
+## Known issues
+
+### Calling `std::prev` on an `msd::zip` compiles, but fails at runtime on some std containers.
+
+* list
+* forward_list
+* unordered_set
+* unordered_multiset
+* unordered_map
+* unordered_multimap
+
+The `msd::zip` iterator is bidirectional to better control when you want to stop iterating.
+
+To get only some of the elements from a zip, in C++23 you can use `std::views::take`:
+```c++
+std::forward_list<int> first_list{1, 2, 3, 4, 5};
+std::forward_list<int> second_list{1, 2, 3, 4};
+auto forward_zip = std::views::zip(first_list, second_list);
+
+for (auto [a, b] : forward_zip | std::views::take(3)) {
+    std::cout << a << ", " << b << "\n";
+}
+```
+
+With `msd::zip`, you can write:
+```c++
+for (auto it = forward_zip.begin(); it != std::prev(forward_zip.end()); ++it) {
+    auto [a, b] = *it;
+    std::cout << a << ", " << b << "\n";
+}
+```
+But it does not work with the mentioned containers.
+
 ## Development
 
 ### Tools
@@ -69,9 +102,6 @@ See [tests](tests/).
 * const correctness
 * Write benchmarks
 * Ignore google headers from clang-tidy
-* ContainersAndAlgorithms test fails at `EXPECT_EQ(it, std::prev(const_zip.end()));` for std::list
-    * Can the zip iterator really be bidirectional?
-    * Document or conditionaly set the iterator tag by the containers types
 * Consider checked access that returns an optional reference
 * Do not allow to mix begin/end with cbegin/cend
 * Run clang-tidy, clang-format in CI/file save

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ See [tests](tests/).
 
 The `msd::zip` iterator is bidirectional to better control when you want to stop iterating.
 
-To get only some of the elements from a zip, in C++23 you can use `std::views::take`:
+To get only some of the elements from a C++23 zip, you can use `std::views::take`:
 ```c++
 std::forward_list<int> first_list{1, 2, 3, 4, 5};
 std::forward_list<int> second_list{1, 2, 3, 4};

--- a/include/msd/zip.hpp
+++ b/include/msd/zip.hpp
@@ -107,15 +107,17 @@ class zip {
         zip_iterator<typename std::conditional_t<std::is_const_v<Containers>, typename Containers::const_iterator,
                                                  typename Containers::iterator>...>;
 
+    using const_iterator = zip_iterator<typename Containers::const_iterator...>;
+
     using value_type = typename iterator::value_type;
 
     explicit zip(Containers&... containers) noexcept : containers_{containers...} {}
 
-    iterator begin() const { return begin_impl(std::index_sequence_for<Containers...>{}); }
-    iterator end() const { return end_impl(std::index_sequence_for<Containers...>{}); }
+    iterator begin() const { return begin_impl<iterator>(std::index_sequence_for<Containers...>{}); }
+    iterator end() const { return end_impl<iterator>(std::index_sequence_for<Containers...>{}); }
 
-    iterator cbegin() const { return begin_impl(std::index_sequence_for<Containers...>{}); }
-    iterator cend() const { return end_impl(std::index_sequence_for<Containers...>{}); }
+    const_iterator cbegin() const { return begin_impl<const_iterator>(std::index_sequence_for<Containers...>{}); }
+    const_iterator cend() const { return end_impl<const_iterator>(std::index_sequence_for<Containers...>{}); }
 
     [[nodiscard]] std::size_t size() const { return size_impl(std::index_sequence_for<Containers...>{}); }
 
@@ -154,16 +156,16 @@ class zip {
     }
 
    private:
-    template <std::size_t... I>
-    iterator begin_impl(std::index_sequence<I...>) const noexcept
+    template <typename Iterator, std::size_t... I>
+    Iterator begin_impl(std::index_sequence<I...>) const noexcept
     {
-        return iterator{std::get<I>(containers_).begin()...};
+        return Iterator{std::get<I>(containers_).begin()...};
     }
 
-    template <std::size_t... I>
-    iterator end_impl(std::index_sequence<I...>) const noexcept
+    template <typename Iterator, std::size_t... I>
+    Iterator end_impl(std::index_sequence<I...>) const noexcept
     {
-        return std::next(iterator{std::get<I>(containers_).begin()...}, size());
+        return std::next(Iterator{std::get<I>(containers_).begin()...}, size());
     }
 
     template <std::size_t... I>

--- a/tests/zip_integration_test.cpp
+++ b/tests/zip_integration_test.cpp
@@ -48,7 +48,7 @@ TEST(ZipIntegrationTest, ContainersAndAlgorithms)
     std::unordered_multimap<int, int> unordered_multimap{{1, 1}, {2, 2}, {3, 3}, {4, 4}};
 
     const msd::zip unordered_zip(unordered_set, unordered_multiset, unordered_map, unordered_multimap);
-    const bool any_is_negative = std::any_of(unordered_zip.begin(), unordered_zip.cend(), [](auto tuple) {
+    const bool any_is_negative = std::any_of(unordered_zip.cbegin(), unordered_zip.cend(), [](auto tuple) {
         auto [uset, umset, umap, umm] = tuple;
         return uset < 0 || umset < 0 || umap.second < 0 || umm.second < 0;
     });
@@ -83,7 +83,7 @@ TEST(ZipIntegrationTest, ContainersAndAlgorithms)
     EXPECT_EQ(iterations, 3);
 
     iterations = 0;
-    for (auto it = std::next(zip2.begin()); it != std::prev(zip2.end()); ++it) {
+    for (auto it = std::next(zip2.cbegin()); it != std::prev(zip2.cend()); ++it) {
         ++iterations;
     }
     EXPECT_EQ(iterations, 1);

--- a/tests/zip_test.cpp
+++ b/tests/zip_test.cpp
@@ -32,9 +32,11 @@ TEST_F(ZipTest, Begin)
     EXPECT_EQ(b0, 4);
     EXPECT_EQ(c0, 6);
 
+    b0 = 2;
+
     auto [ca0, cb0, cc0] = *const_zip_.begin();
     EXPECT_EQ(ca0, 1);
-    EXPECT_EQ(cb0, 4);
+    EXPECT_EQ(cb0, 2);
     EXPECT_EQ(cc0, 6);
 
     EXPECT_EQ(zip_.begin() + 2, zip_.end());


### PR DESCRIPTION
Document known issues.
Use const iterator for cbegin/cend.
Add spell checker.